### PR TITLE
ci: fix publish workflow permissions requirements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ jobs:
   publish:
     uses: AwesomeHamster/workflows/.github/workflows/publish.yml@master
     permissions:
+      id-token: write
       contents: write
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The provenance requires id-token permission